### PR TITLE
changed Intro level cam time and made transition longer to kid

### DIFF
--- a/Assets/Scenes/Level10.unity
+++ b/Assets/Scenes/Level10.unity
@@ -6207,9 +6207,9 @@ Transform:
   - {fileID: 1582697339}
   - {fileID: 1322056803}
   - {fileID: 2106907395}
-  - {fileID: 1572808446}
   - {fileID: 1021931350}
   - {fileID: 1259492218}
+  - {fileID: 1572808446}
   - {fileID: 829007757}
   - {fileID: 1755016136}
   - {fileID: 794875410}
@@ -7619,12 +7619,16 @@ PrefabInstance:
       value: -4.1709156
       objectReference: {fileID: 0}
     - target: {fileID: 2333194340299278461, guid: b69d320fd1325254695e925963f65aa7, type: 3}
+      propertyPath: m_DefaultBlend.m_Time
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2333194340299278461, guid: b69d320fd1325254695e925963f65aa7, type: 3}
       propertyPath: m_ParentHash.Array.size
       value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 2333194340299278461, guid: b69d320fd1325254695e925963f65aa7, type: 3}
       propertyPath: m_ChildCameras.Array.size
-      value: 0
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 2333194340299278461, guid: b69d320fd1325254695e925963f65aa7, type: 3}
       propertyPath: m_Instructions.Array.size

--- a/Assets/Scripts/Cinemachine/CinemachineBehavior.cs
+++ b/Assets/Scripts/Cinemachine/CinemachineBehavior.cs
@@ -11,6 +11,9 @@ public class CinemachineBehavior : MonoBehaviour
     private SwitchCharacter switchCharacter; //to find which character is active
     private Animator animator;
     private int camNum = 0;
+    private float wholeLevelShownTime = 3f;
+    private float transitionToKidTime = 2f;
+    private float switchCameraTime = .75f;
     private void Awake()
     {
         animator = GetComponent<Animator>();
@@ -21,8 +24,12 @@ public class CinemachineBehavior : MonoBehaviour
     private IEnumerator BeginLevel()
     {
         animator.Play("Level");
-        yield return new WaitForSeconds(5);
+        animator.gameObject.GetComponent<CinemachineStateDrivenCamera>().m_DefaultBlend.m_Time = transitionToKidTime;
+        Debug.Log(animator.gameObject.GetComponent<CinemachineStateDrivenCamera>().m_DefaultBlend.m_Time);
+        yield return new WaitForSeconds(wholeLevelShownTime);
         SwitchCamera();
+        yield return new WaitForSeconds(transitionToKidTime);
+        animator.gameObject.GetComponent<CinemachineStateDrivenCamera>().m_DefaultBlend.m_Time = switchCameraTime;
     }
     // Start is called before the first frame update
     void Start()


### PR DESCRIPTION
whole level time shown changed to 3 seconds from 5 seconds
transition to kid is now 2 seconds instead of 0.75 seconds.